### PR TITLE
Add nova client interface

### DIFF
--- a/novajoin/join.py
+++ b/novajoin/join.py
@@ -24,7 +24,7 @@ from novajoin import exception
 from novajoin.glance import get_default_image_service
 from novajoin.ipa import IPAClient
 from novajoin import keystone_client
-from novajoin.nova import NovaClient
+from novajoin import nova_client
 
 
 CONF = cfg.CONF
@@ -194,8 +194,7 @@ class JoinController(Controller):
 
         # Ensure this instance exists in nova and retrieve the
         # name of the user that requested it.
-        novaclient = NovaClient()
-        instance = novaclient.get_instance(instance_id)
+        instance = nova_client.get_instance(instance_id)
         if instance is None:
             msg = 'No such instance-id, %s' % instance_id
             LOG.error(msg)

--- a/novajoin/nova_client.py
+++ b/novajoin/nova_client.py
@@ -1,0 +1,33 @@
+# Copyright 2016 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from novaclient import client
+import novaclient.exceptions
+from novajoin import keystone_client
+
+
+NOVA_API_VERSION = 2
+
+
+def get_client():
+    session = keystone_client.get_session()
+    return client.Client(NOVA_API_VERSION, session=session)
+
+
+def get_instance(instance_id):
+    client = get_client()
+    try:
+        return client.servers.get(instance_id)
+    except novaclient.exceptions.NotFound:
+        return None


### PR DESCRIPTION
This adds the nova_client interface (similar to the keystone_client
interface that was already there), which simply adds the function
needed (get_instance).

It's hardcoded to use nova API v2, since 1 should no longer be
supported.