### PR TITLE
Remove version definition from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = novajoin
-version = 1.0.8
 description = Nova integration to enroll IPA clients
 author = Rob Crittenden
 author_email = rcritten@redhat.com


### PR DESCRIPTION
Setting a specific version in setup.cfg tells PBR to constraint
itself and use that specific version. This is called preversioning as
stated in the PBR documentation[1]. And leads to the issue of
tox not being able to run, since the running of setup.py breaks,
because there is a version mismatch.

Other projects have dealt with the same issue, such as
manilaclient[2], and ended up removing this version from setup.cfg.

[1] http://docs.openstack.org/developer/pbr/#version
[2] https://bugs.launchpad.net/python-manilaclient/+bug/1395067